### PR TITLE
Added ExpandableResultsEntry

### DIFF
--- a/src/client/java/io/wispforest/limelight/api/entry/ExpandableResultEntry.java
+++ b/src/client/java/io/wispforest/limelight/api/entry/ExpandableResultEntry.java
@@ -1,0 +1,15 @@
+package io.wispforest.limelight.api.entry;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+
+/**
+ * A result entry which contain child entries that will show when this entry is selected.
+ *
+ * @apiNote This entry type is experimental, and may be removed in a later update.
+ */
+@ApiStatus.Experimental
+public non-sealed interface ExpandableResultEntry extends ResultEntry {
+    List<ResultEntry> getChildren();
+}

--- a/src/client/java/io/wispforest/limelight/api/entry/ExpandableResultEntry.java
+++ b/src/client/java/io/wispforest/limelight/api/entry/ExpandableResultEntry.java
@@ -11,5 +11,5 @@ import java.util.List;
  */
 @ApiStatus.Experimental
 public non-sealed interface ExpandableResultEntry extends ResultEntry {
-    List<ResultEntry> getChildren();
+    List<ResultEntry> children();
 }

--- a/src/client/java/io/wispforest/limelight/api/entry/ResultEntry.java
+++ b/src/client/java/io/wispforest/limelight/api/entry/ResultEntry.java
@@ -7,7 +7,7 @@ import net.minecraft.util.Identifier;
 /**
  * Represents a result entry in the Limelight GUI.
  */
-public sealed interface ResultEntry permits InvokeResultEntry, SetSearchTextEntry, ToggleResultEntry {
+public sealed interface ResultEntry permits InvokeResultEntry, SetSearchTextEntry, ToggleResultEntry, ExpandableResultEntry {
     /**
      * @return the extension that generated this entry
      */

--- a/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
+++ b/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
@@ -73,7 +73,7 @@ public interface LimelightTheme {
 
         @Override
         public int childSourceExtensionColor() {
-            return 0xFF666666;
+            return 0xFF999999;
         }
     };
 

--- a/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
+++ b/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
@@ -30,12 +30,12 @@ public interface LimelightTheme {
         }
 
         @Override
-        public int expandedResultChildEntryBackgroundColor() {
+        public int childBackgroundColor() {
             return 0x33000000;
         }
 
         @Override
-        public int expandedResultChildEntrySourceExtensionColor() {
+        public int childSourceExtensionColor() {
             return 0xFFEEEEEE;
         }
     };
@@ -67,12 +67,12 @@ public interface LimelightTheme {
         }
 
         @Override
-        public int expandedResultChildEntryBackgroundColor() {
+        public int childBackgroundColor() {
             return 0x33000000;
         }
 
         @Override
-        public int expandedResultChildEntrySourceExtensionColor() {
+        public int childSourceExtensionColor() {
             return 0xFF666666;
         }
     };
@@ -94,7 +94,7 @@ public interface LimelightTheme {
 
     int resultEntryTextColor();
 
-    int expandedResultChildEntryBackgroundColor();
+    int childBackgroundColor();
 
-    int expandedResultChildEntrySourceExtensionColor();
+    int childSourceExtensionColor();
 }

--- a/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
+++ b/src/client/java/io/wispforest/limelight/impl/config/LimelightTheme.java
@@ -28,6 +28,16 @@ public interface LimelightTheme {
         public int resultEntryTextColor() {
             return 0x000000;
         }
+
+        @Override
+        public int expandedResultChildEntryBackgroundColor() {
+            return 0x33000000;
+        }
+
+        @Override
+        public int expandedResultChildEntrySourceExtensionColor() {
+            return 0xFFEEEEEE;
+        }
     };
 
     LimelightTheme DARK = new LimelightTheme() {
@@ -55,6 +65,16 @@ public interface LimelightTheme {
         public int resultEntryTextColor() {
             return 0xFFFFFF;
         }
+
+        @Override
+        public int expandedResultChildEntryBackgroundColor() {
+            return 0x33000000;
+        }
+
+        @Override
+        public int expandedResultChildEntrySourceExtensionColor() {
+            return 0xFF666666;
+        }
     };
 
     static LimelightTheme current() {
@@ -73,4 +93,8 @@ public interface LimelightTheme {
     int sourceExtensionColor();
 
     int resultEntryTextColor();
+
+    int expandedResultChildEntryBackgroundColor();
+
+    int expandedResultChildEntrySourceExtensionColor();
 }

--- a/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
@@ -3,21 +3,33 @@ package io.wispforest.limelight.impl.ui;
 import io.wispforest.limelight.impl.config.LimelightTheme;
 import io.wispforest.owo.ui.component.LabelComponent;
 import io.wispforest.owo.ui.core.CursorStyle;
+import io.wispforest.owo.ui.core.Insets;
 import io.wispforest.owo.ui.core.OwoUIDrawContext;
+import io.wispforest.owo.ui.util.Delta;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.RotationAxis;
 
 class ExpandIndicatorComponent extends LabelComponent {
 
-    public final boolean isExpanded;
+    protected float rotation = 0;
+    protected float targetRotation = 0;
 
-    public ExpandIndicatorComponent(boolean isExpanded) {
-        super(Text.literal(">").withColor(LimelightTheme.current().sourceExtensionColor()).formatted(Formatting.BOLD));
+    public ExpandIndicatorComponent(int color) {
+        super(Text.literal(">").withColor(color).formatted(Formatting.BOLD));
+//        this.margins(Insets.of(0, 0, 5, 10));
         this.cursorStyle(CursorStyle.HAND);
-        this.isExpanded = isExpanded;
     }
 
+    public void toggle() {
+        targetRotation = targetRotation == 0 ? 90 : 0;
+    }
+
+    @Override
+    public void update(float delta, int mouseX, int mouseY) {
+        super.update(delta, mouseX, mouseY);
+        this.rotation += Delta.compute(this.rotation, this.targetRotation, delta * .65);
+    }
 
     @Override
     public void draw(OwoUIDrawContext context, int mouseX, int mouseY, float partialTicks, float delta) {
@@ -25,8 +37,7 @@ class ExpandIndicatorComponent extends LabelComponent {
 
         matrices.push();
         matrices.translate(this.x + this.width / 2f - 1, this.y + this.height / 2f - 1, 0);
-        if (isExpanded)
-            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(this.rotation));
         matrices.translate(-(this.x + this.width / 2f - 1), -(this.y + this.height / 2f - 1), 0);
 
         super.draw(context, mouseX, mouseY, partialTicks, delta);

--- a/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
@@ -1,9 +1,7 @@
 package io.wispforest.limelight.impl.ui;
 
-import io.wispforest.limelight.impl.config.LimelightTheme;
 import io.wispforest.owo.ui.component.LabelComponent;
 import io.wispforest.owo.ui.core.CursorStyle;
-import io.wispforest.owo.ui.core.Insets;
 import io.wispforest.owo.ui.core.OwoUIDrawContext;
 import io.wispforest.owo.ui.util.Delta;
 import net.minecraft.text.Text;
@@ -17,7 +15,6 @@ class ExpandIndicatorComponent extends LabelComponent {
 
     public ExpandIndicatorComponent(int color) {
         super(Text.literal(">").withColor(color).formatted(Formatting.BOLD));
-//        this.margins(Insets.of(0, 0, 5, 10));
         this.cursorStyle(CursorStyle.HAND);
     }
 

--- a/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/ExpandIndicatorComponent.java
@@ -1,0 +1,35 @@
+package io.wispforest.limelight.impl.ui;
+
+import io.wispforest.limelight.impl.config.LimelightTheme;
+import io.wispforest.owo.ui.component.LabelComponent;
+import io.wispforest.owo.ui.core.CursorStyle;
+import io.wispforest.owo.ui.core.OwoUIDrawContext;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.RotationAxis;
+
+class ExpandIndicatorComponent extends LabelComponent {
+
+    public final boolean isExpanded;
+
+    public ExpandIndicatorComponent(boolean isExpanded) {
+        super(Text.literal(">").withColor(LimelightTheme.current().sourceExtensionColor()).formatted(Formatting.BOLD));
+        this.cursorStyle(CursorStyle.HAND);
+        this.isExpanded = isExpanded;
+    }
+
+
+    @Override
+    public void draw(OwoUIDrawContext context, int mouseX, int mouseY, float partialTicks, float delta) {
+        var matrices = context.getMatrices();
+
+        matrices.push();
+        matrices.translate(this.x + this.width / 2f - 1, this.y + this.height / 2f - 1, 0);
+        if (isExpanded)
+            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90));
+        matrices.translate(-(this.x + this.width / 2f - 1), -(this.y + this.height / 2f - 1), 0);
+
+        super.draw(context, mouseX, mouseY, partialTicks, delta);
+        matrices.pop();
+    }
+}

--- a/src/client/java/io/wispforest/limelight/impl/ui/LimelightScreen.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/LimelightScreen.java
@@ -52,7 +52,7 @@ public class LimelightScreen extends BaseOwoScreen<FlowLayout> {
             // TODO: actually use our own texture instead of piggy-backing off owo-lib
             .child(Components.texture(Identifier.of("owo:textures/gui/config_search.png"), 0, 0, 16, 16, 16, 16));
 
-        this.searchBox = new SearchBoxComponent(Sizing.fill(), () -> {
+        this.searchBox = new SearchBoxComponent(Sizing.expand(), () -> {
             if (firstResult != null) firstResult.run();
         });
 

--- a/src/client/java/io/wispforest/limelight/impl/ui/ResultEntryComponent.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/ResultEntryComponent.java
@@ -22,16 +22,18 @@ public class ResultEntryComponent extends FlowLayout {
     private final @Nullable SmallCheckboxComponent toggleBox;
     private final @Nullable ExpandIndicatorComponent expandIndicator;
     private final Surface baseSurface;
+    private final boolean isChild;
 
-    public ResultEntryComponent(LimelightScreen screen, ResultEntry entry, boolean child, boolean expanded) {
+    public ResultEntryComponent(LimelightScreen screen, ResultEntry entry, boolean isChild) {
         super(Sizing.fill(), Sizing.content(), Algorithm.HORIZONTAL);
         this.screen = screen;
         this.entry = entry;
+        this.isChild = isChild;
 
         LimelightTheme theme = LimelightTheme.current();
 
         padding(Insets.both(2, 4));
-        baseSurface = !child ? Surface.BLANK : Surface.flat(theme.childBackgroundColor());
+        baseSurface = !isChild ? Surface.BLANK : Surface.flat(theme.childBackgroundColor());
         surface(baseSurface);
 
         MutableText labelBuilder = Text.empty();
@@ -49,7 +51,7 @@ public class ResultEntryComponent extends FlowLayout {
         labelBuilder.append(
             Text.empty()
                 .append(entry.extension().name())
-                .styled(x -> x.withColor(child ? theme.childSourceExtensionColor() : theme.sourceExtensionColor()))
+                .styled(x -> x.withColor(isChild ? theme.childSourceExtensionColor() : theme.sourceExtensionColor()))
                 .styled(x -> x.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltipText)))
         );
 
@@ -73,9 +75,9 @@ public class ResultEntryComponent extends FlowLayout {
             this.toggleBox = null;
         }
 
-        if (entry instanceof ExpandableResultEntry) {
+        if (entry instanceof ExpandableResultEntry && !isChild) {
             child(Components.spacer().verticalSizing(Sizing.fixed(0)));
-            this.expandIndicator = new ExpandIndicatorComponent(child ? theme.childSourceExtensionColor() : theme.sourceExtensionColor());
+            this.expandIndicator = new ExpandIndicatorComponent(isChild ? theme.childSourceExtensionColor() : theme.sourceExtensionColor());
             child(this.expandIndicator);
         }
         else {
@@ -102,7 +104,7 @@ public class ResultEntryComponent extends FlowLayout {
                 toggleBox.checked(!toggleBox.checked());
             }
             case ExpandableResultEntry expanded -> {
-                if (parent != null) {
+                if (parent != null && !isChild) {
                     ((ResultsContainerComponent) parent).toggleExpanded(this, expanded);
                     expandIndicator.toggle();
                 }

--- a/src/client/java/io/wispforest/limelight/impl/ui/ResultsContainerComponent.java
+++ b/src/client/java/io/wispforest/limelight/impl/ui/ResultsContainerComponent.java
@@ -53,7 +53,7 @@ public class ResultsContainerComponent extends FlowLayout {
                     List<ResultEntry> childEntries = resultEntry.children();
                     length = childEntries.size();
                     for (int i = 0; i < length; i++)
-                        child(index+1+i, new ResultEntryComponent(screen, childEntries.get(i), true, false));
+                        child(index+1+i, new ResultEntryComponent(screen, childEntries.get(i), true));
                 }
                 expanded.put(resultEntry, length);
             }
@@ -79,8 +79,7 @@ public class ResultsContainerComponent extends FlowLayout {
             clearChildren();
 
             for (var entry : results) {
-                boolean isExpanded = entry instanceof ExpandableResultEntry && expanded.getOrDefault(entry.entryId(), 0) > 0;
-                var result = new ResultEntryComponent(screen, entry, false, isExpanded);
+                var result = new ResultEntryComponent(screen, entry, false);
 
                 if (screen.firstResult == null) screen.firstResult = result;
 

--- a/src/client/java/io/wispforest/limelight/mixin/TextFieldWidgetMixin.java
+++ b/src/client/java/io/wispforest/limelight/mixin/TextFieldWidgetMixin.java
@@ -44,7 +44,7 @@ public class TextFieldWidgetMixin implements TextFieldWidgetAccess {
         if (limelight$drawShadow) {
             return original.call(instance, textRenderer, text, x, y, color);
         } else {
-            return instance.drawText(textRenderer, text, x, y, color, false);
+            return instance.drawText(textRenderer, text, x, y, color, false) + 1;
         }
     }
 }


### PR DESCRIPTION
Adds a ExpandableResultEntry, which has a method to get child entries. When a ExpandableResultEntry is selected, it adds it's children below it (with adjusted background color) and the expandable icon is rotated. Child-entries don't sorted by usage, and this is intentional. Though the theming might need adjustment

![image](https://github.com/user-attachments/assets/80b767cc-e20c-4886-9f88-cef89ee43be3)
![image](https://github.com/user-attachments/assets/16355881-54a7-488e-af7d-89eea1bde670)
